### PR TITLE
chore(docs-issue-reporting): fix links to bug report and feature request

### DIFF
--- a/misc/issue_reporting.md
+++ b/misc/issue_reporting.md
@@ -6,10 +6,10 @@ This section guides you through submitting a bug report for the AWS Provider for
 
 - [ ] **Determine the right repository**: If it's a general issue please open the bug in [cloudquery/cloudquery](https://github.com/cloudquery/cloudquery).
 - [ ] **Search for possible duplicated**: If you see an already open issue, feel free to comment and add additional information. If the issue is closed please open a new one and link to the closed.
-- [ ] **Fill In the bug report template**: Try to fill-in as much as possible with many details the [bug report template](../../.github./ISSUE_TEMPLATE/bug_report.yml)
+- [ ] **Fill In the bug report template**: Try to fill-in as much as possible with many details the [bug report template](../../.github/ISSUE_TEMPLATE/bug_report.yml)
 
 ## Suggesting Enhancements
 
 - [ ] **Determine the right repository**: If it's a general issue please open the bug in [cloudquery/cloudquery](https://github.com/cloudquery/cloudquery).
 - [ ] **Search for possible duplicated**: If you see an already open issue, feel free to comment and add additional information. If the issue is closed please open a new one and link to the closed.
-- [ ] **Fill In the Feature request template**: Try to fill-in as much as possible with many details the [feature request template](../../.github./ISSUE_TEMPLATE/feature_request.yml)
+- [ ] **Fill In the Feature request template**: Try to fill-in as much as possible with many details the [feature request template](../../.github/ISSUE_TEMPLATE/feature_request.yml)


### PR DESCRIPTION
Hi 👋 

While going over the [issue reporting doc in cq-provider-aws](https://github.com/erezrokah/cq-provider-aws/blob/main/docs/contributing/issue_reporting.md), I noticed some broken links.

This PR fixes those links.