### PR TITLE
chore(docs-issue-reporting): link issue templates to .github repo

### DIFF
--- a/misc/issue_reporting.md
+++ b/misc/issue_reporting.md
@@ -6,10 +6,10 @@ This section guides you through submitting a bug report for the AWS Provider for
 
 - [ ] **Determine the right repository**: If it's a general issue please open the bug in [cloudquery/cloudquery](https://github.com/cloudquery/cloudquery).
 - [ ] **Search for possible duplicated**: If you see an already open issue, feel free to comment and add additional information. If the issue is closed please open a new one and link to the closed.
-- [ ] **Fill In the bug report template**: Try to fill-in as much as possible with many details the [bug report template](../../.github/ISSUE_TEMPLATE/bug_report.yml)
+- [ ] **Fill In the bug report template**: Try to fill-in as much as possible with many details the [bug report template](https://github.com/cloudquery/.github/tree/main/.github/ISSUE_TEMPLATE/bug_report.yml)
 
 ## Suggesting Enhancements
 
 - [ ] **Determine the right repository**: If it's a general issue please open the bug in [cloudquery/cloudquery](https://github.com/cloudquery/cloudquery).
 - [ ] **Search for possible duplicated**: If you see an already open issue, feel free to comment and add additional information. If the issue is closed please open a new one and link to the closed.
-- [ ] **Fill In the Feature request template**: Try to fill-in as much as possible with many details the [feature request template](../../.github/ISSUE_TEMPLATE/feature_request.yml)
+- [ ] **Fill In the Feature request template**: Try to fill-in as much as possible with many details the [feature request template](https://github.com/cloudquery/.github/tree/main/.github/ISSUE_TEMPLATE/feature_request.yml)


### PR DESCRIPTION
Follow up to https://github.com/cloudquery/.github/pull/20

Looks like we don't sync the issue templates from the `.github` repo to other repos (which makes sense to me) so using relatives paths doesn't work.

For example https://github.com/cloudquery/cq-provider-gcp/pull/193 and https://github.com/cloudquery/cq-provider-azure/pull/231.

The reason https://github.com/cloudquery/cq-provider-aws/pull/707 worked is that repo already has the files duplicated.

After this PR is merged I'll follow up with the removal of https://github.com/cloudquery/cq-provider-azure/blob/main/.github/ISSUE_TEMPLATE/ and https://github.com/cloudquery/cq-provider-aws/tree/main/.github/ISSUE_TEMPLATE

 