### PR TITLE
fix(ci): don't ignore workflow files changes

### DIFF
--- a/workflows/common/lint_golang.yml
+++ b/workflows/common/lint_golang.yml
@@ -9,7 +9,6 @@ on:
       - main
     paths-ignore:
       - 'terraform/**'
-      - '.github/**'
       - 'scripts/**'
 
 jobs:

--- a/workflows/providers/lint_doc.yml
+++ b/workflows/providers/lint_doc.yml
@@ -9,7 +9,6 @@ on:
       - main
     paths-ignore:
       - 'terraform/**'
-      - '.github/**'
       - 'scripts/**'
 
 jobs:

--- a/workflows/providers/test_integration.yml
+++ b/workflows/providers/test_integration.yml
@@ -12,7 +12,6 @@ on:
       - main
     paths-ignore:
       - 'terraform/**'
-      - '.github/**'
       - 'scripts/**'
 
 jobs:

--- a/workflows/providers/test_unit.yml
+++ b/workflows/providers/test_unit.yml
@@ -10,7 +10,6 @@ on:
       - main
     paths-ignore:
       - 'terraform/**'
-      - '.github/**'
       - 'scripts/**'
 
 jobs:


### PR DESCRIPTION
We ignore workflow file changes in some of our CI jobs.

This means if a workflow had changed, it won't trigger the checks and the CI won't run.
See https://github.com/cloudquery/cq-provider-digitalocean/pull/52 which is blocked due to required CI checks.

This PR fixes the issue by not ignoring `.github` files.