### PR TITLE
fix: Remove cq-provider-terraform

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -18,7 +18,6 @@ group:
       cloudquery/cq-provider-k8s
       cloudquery/cq-provider-okta
       cloudquery/cq-provider-template
-      # cloudquery/cq-provider-terraform
       cloudquery/helm-charts
   # All repos in cloudquery org
   - files:
@@ -34,7 +33,6 @@ group:
       cloudquery/cq-provider-k8s
       cloudquery/cq-provider-okta
       cloudquery/cq-provider-template
-      # cloudquery/cq-provider-terraform
       cloudquery/helm-charts
 
 
@@ -63,7 +61,6 @@ group:
       cloudquery/cq-provider-k8s
       cloudquery/cq-provider-okta
       cloudquery/cq-provider-template
-      # cloudquery/cq-provider-terraform
 
   # providers with terraform
   - files:


### PR DESCRIPTION
Fixes https://github.com/cloudquery/.github/runs/6189216680?check_suite_focus=true#step:3:225

We can't really comment a line to ignore a repo, so this PR removes it