### PR TITLE
fix(providers): Exclude k8s from integration tests

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -44,6 +44,8 @@ group:
         dest: .github/workflows/
       - source: workflows/providers
         dest: .github/workflows/
+        exclude: |
+          test_integration.yml.generated-cq-provider-k8s.yml
       - .github/release.yml
       - source: providers.golangci.yml
         dest: .golangci.yml


### PR DESCRIPTION
Brings https://github.com/cloudquery/cq-provider-k8s/pull/85 into this repo