### PR TITLE
fix: Exclude k8s test_integration

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -45,7 +45,7 @@ group:
       - source: workflows/providers
         dest: .github/workflows/
         exclude: |
-          test_integration.yml.generated-cq-provider-k8s.yml
+          test_integration.generated-cq-provider-k8s.yml
       - .github/release.yml
       - source: providers.golangci.yml
         dest: .golangci.yml


### PR DESCRIPTION
Follow up on https://github.com/cloudquery/.github/pull/63