### PR TITLE
fix: Sync file

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -46,7 +46,6 @@ group:
         dest: .github/workflows/
         exclude: |
           test_integration.generated-cq-provider-k8s.yml
-      - .github/release.yml
       - source: providers.golangci.yml
         dest: .golangci.yml
       - source: .github/renovate.json5


### PR DESCRIPTION
The `release.yml` file was removed in https://github.com/cloudquery/.github/pull/54