### PR TITLE
fix: Policies issues triage

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -89,6 +89,7 @@ group:
         dest: .github/workflows/
         exclude: |
           lint_golang.yml
+          issue_to_project.yml
       - source: workflows/policies
         dest: .github/workflows
     repos: |

--- a/workflows/policies/issue_to_project.yml
+++ b/workflows/policies/issue_to_project.yml
@@ -1,0 +1,25 @@
+name: Add issue to project
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+
+# map fields with customized labels
+env:
+  todo: Triage
+
+jobs:
+  issue_opened_or_reopened:
+    name: issue_opened_or_reopened
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    steps:
+      - name: Move issue to ${{ env.todo }}
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        with:
+          gh_token: ${{ secrets.GH_CQ_BOT }}
+          organization: cloudquery-policies
+          project_id: 1
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: ${{ env.todo }} # Target status


### PR DESCRIPTION
Policies are on a different GitHub org, and require a different project board to triage issues