### PR TITLE
feat: Support pre-releases

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -111,6 +111,8 @@ cloudquery/cloudquery:
     dest: .github/renovate.json5
   - source: misc/repo-specific/cloudquery/.goreleaser.yaml
     dest: .goreleaser.yaml
+  - source: misc/repo-specific/cloudquery/.goreleaser.prerelease.yaml
+    dest: .goreleaser.prerelease.yaml
 
 cloudquery/helm-charts:
   - source: workflows/common/

--- a/misc/repo-specific/cloudquery/.goreleaser.prerelease.yaml
+++ b/misc/repo-specific/cloudquery/.goreleaser.prerelease.yaml
@@ -1,0 +1,67 @@
+# DONT EDIT. This file is synced from https://github.com/cloudquery/.github
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+builds:
+  - flags:
+      - -buildmode=exe
+    env:
+      - GOGC=off
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    main: ./main.go
+    ldflags:
+      - -s -w -X github.com/cloudquery/cloudquery/pkg/core.Version={{.Version}} -X github.com/cloudquery/cloudquery/cmd.Commit={{.Commit}} -X github.com/cloudquery/cloudquery/cmd.Date={{.Date}} -X github.com/cloudquery/cloudquery/cmd.APIKey=${{secrets.RUDDER_API_KEY}}
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+archives:
+  -
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format: binary
+  -
+    id: homebrew
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format: zip
+dockers:
+  -
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - "ghcr.io/cloudquery/cloudquery:latest"
+      - "ghcr.io/cloudquery/cloudquery:{{.Version}}"
+      - "ghcr.io/cloudquery/cloudquery:{{ .Major }}.{{ .Minor }}"
+    build_flag_templates:
+      - "--label=org.opencontainers.image.source=https://github.com/cloudquery/cloudquery"
+checksum:
+  name_template: 'checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      
+release:
+  prerelease: auto

--- a/workflows/policies/release-pr.yml
+++ b/workflows/policies/release-pr.yml
@@ -19,3 +19,17 @@ jobs:
           pull-request-title-pattern: "chore${scope}: Release${component} v${version}"
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
+      - name: Parse semver string
+        if: steps.release.outputs.release_created
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@4f8784f912407f85ba53b686fe2cf85d4ee11a20
+        with:
+          input_string: ${{ steps.release.outputs.tag_name }}
+      - name: Mark as pre-release
+        if: steps.semver_parser.outputs.prerelease != ''
+        uses: tubone24/update_release@6a6e4bf2bea820d75d8a1c014fa5b2be60227cbf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        with:
+          prerelease: true

--- a/workflows/providers/release-pr.yml
+++ b/workflows/providers/release-pr.yml
@@ -19,3 +19,17 @@ jobs:
           pull-request-title-pattern: "chore${scope}: Release${component} v${version}"
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
+      - name: Parse semver string
+        if: steps.release.outputs.release_created
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@4f8784f912407f85ba53b686fe2cf85d4ee11a20
+        with:
+          input_string: ${{ steps.release.outputs.tag_name }}
+      - name: Mark as pre-release
+        if: steps.semver_parser.outputs.prerelease != ''
+        uses: tubone24/update_release@6a6e4bf2bea820d75d8a1c014fa5b2be60227cbf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        with:
+          prerelease: true

--- a/workflows/providers/release.yml
+++ b/workflows/providers/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "*"
+      - 'v*.*.*'
 env:
   CGO_ENABLED: 0
 
@@ -11,6 +11,12 @@ jobs:
   release-binary:
     runs-on: ubuntu-latest
     steps:
+      # This fails for invalid semver strings
+      - name: Parse semver string
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@4f8784f912407f85ba53b686fe2cf85d4ee11a20
+        with:
+          input_string: ${{github.ref_name}}
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/workflows/repo-specific/cloudquery/release-pr.yml
+++ b/workflows/repo-specific/cloudquery/release-pr.yml
@@ -18,3 +18,17 @@ jobs:
           pull-request-title-pattern: "chore${scope}: Release${component} v${version}"
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
+      - name: Parse semver string
+        if: steps.release.outputs.release_created
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@4f8784f912407f85ba53b686fe2cf85d4ee11a20
+        with:
+          input_string: ${{ steps.release.outputs.tag_name }}
+      - name: Mark as pre-release
+        if: steps.semver_parser.outputs.prerelease != ''
+        uses: tubone24/update_release@6a6e4bf2bea820d75d8a1c014fa5b2be60227cbf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        with:
+          prerelease: true

--- a/workflows/repo-specific/cloudquery/release.yml
+++ b/workflows/repo-specific/cloudquery/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - '*'
+      - 'v*.*.*'
 env:
   CGO_ENABLED: 0
 
@@ -11,6 +11,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # This fails for invalid semver strings
+      - 
+        name: Parse semver string
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@4f8784f912407f85ba53b686fe2cf85d4ee11a20
+        with:
+          input_string: ${{github.ref_name}}
       -
         name: Checkout
         uses: actions/checkout@v2
@@ -34,10 +41,23 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | \
           docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
       -
-        name: Run GoReleaser
+        # Publish to GitHub and Homebrew
+        name: Run GoReleaser Release
+        if: steps.semver_parser.outputs.prerelease == ''
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+
+      - 
+        # Publish only to GitHub
+        name: Run GoReleaser PreRelease
+        if: steps.semver_parser.outputs.prerelease != ''
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist --config .goreleaser.prerelease.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}

--- a/workflows/repo-specific/cq-provider-sdk/release-pr.yml
+++ b/workflows/repo-specific/cq-provider-sdk/release-pr.yml
@@ -18,3 +18,17 @@ jobs:
           pull-request-title-pattern: "chore${scope}: Release${component} v${version}"
           bump-minor-pre-major: true
           bump-patch-for-minor-pre-major: true
+      - name: Parse semver string
+        if: steps.release.outputs.release_created
+        id: semver_parser
+        uses: booxmedialtd/ws-action-parse-semver@4f8784f912407f85ba53b686fe2cf85d4ee11a20
+        with:
+          input_string: ${{ steps.release.outputs.tag_name }}
+      - name: Mark as pre-release
+        if: steps.semver_parser.outputs.prerelease != ''
+        uses: tubone24/update_release@6a6e4bf2bea820d75d8a1c014fa5b2be60227cbf
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name }}
+        with:
+          prerelease: true


### PR DESCRIPTION
Adds support for pre-releases.

This will:
1. Tag GitHub releases as pre-releases on matching versions (e.g. `v0.0.1-rc1`)
2. Won't publish cloudquery to homebrew on matching versions  (e.g. `v0.0.1-rc1`)