### PR TITLE
fix: Remove redundant exclude

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -46,8 +46,6 @@ group:
         dest: .github/workflows/
       - source: workflows/providers
         dest: .github/workflows/
-        exclude: |
-          test_integration.generated-cq-provider-k8s.yml
       - source: providers.golangci.yml
         dest: .golangci.yml
       - source: .github/renovate.json5


### PR DESCRIPTION
This is not required as we changed the GitHub action to ignore templates without a matching values file.