### PR TITLE
fix: Set Rudder API key

### DIFF
--- a/misc/repo-specific/cloudquery/.goreleaser.prerelease.yaml
+++ b/misc/repo-specific/cloudquery/.goreleaser.prerelease.yaml
@@ -11,7 +11,7 @@ builds:
       - GO111MODULE=on
     main: ./main.go
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/pkg/core.Version={{.Version}} -X github.com/cloudquery/cloudquery/cmd.Commit={{.Commit}} -X github.com/cloudquery/cloudquery/cmd.Date={{.Date}} -X github.com/cloudquery/cloudquery/cmd.APIKey=${{secrets.RUDDER_API_KEY}}
+      - -s -w -X github.com/cloudquery/cloudquery/pkg/core.Version={{.Version}} -X github.com/cloudquery/cloudquery/cmd.Commit={{.Commit}} -X github.com/cloudquery/cloudquery/cmd.Date={{.Date}} -X github.com/cloudquery/cloudquery/cmd.APIKey=28iMwucm5GXsoevNGSfDl1LC6zV
     goos:
       - windows
       - linux

--- a/misc/repo-specific/cloudquery/.goreleaser.yaml
+++ b/misc/repo-specific/cloudquery/.goreleaser.yaml
@@ -11,7 +11,7 @@ builds:
       - GO111MODULE=on
     main: ./main.go
     ldflags:
-      - -s -w -X github.com/cloudquery/cloudquery/pkg/core.Version={{.Version}} -X github.com/cloudquery/cloudquery/cmd.Commit={{.Commit}} -X github.com/cloudquery/cloudquery/cmd.Date={{.Date}} -X github.com/cloudquery/cloudquery/cmd.APIKey=${{secrets.RUDDER_API_KEY}}
+      - -s -w -X github.com/cloudquery/cloudquery/pkg/core.Version={{.Version}} -X github.com/cloudquery/cloudquery/cmd.Commit={{.Commit}} -X github.com/cloudquery/cloudquery/cmd.Date={{.Date}} -X github.com/cloudquery/cloudquery/cmd.APIKey=28iMwucm5GXsoevNGSfDl1LC6zV
     goos:
       - windows
       - linux


### PR DESCRIPTION
Hardcode the key since it's not a secret and we can't use GitHub secrets directly in a `.goreleaser.yaml` file