### PR TITLE
feat: Validate migrations

### DIFF
--- a/workflows/providers/validate_migrations.yml
+++ b/workflows/providers/validate_migrations.yml
@@ -1,0 +1,97 @@
+# DONT EDIT. This file is synced from https://github.com/cloudquery/.github/.github
+name: validate_migrations
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate_migrations:
+    name: Validate migrations
+    runs-on: ubuntu-latest
+    steps:
+      - id: latest-release
+        if: github.head_ref == 'release-please--branches--main'
+        uses: pozetroninc/github-action-get-latest-release@57753c3124f4365ae77b2b8111cae1f71195572a
+        with:
+          repository: ${{ github.repository }}
+          excludes: prerelease, draft
+      - uses: actions/checkout@v3
+        if: github.head_ref == 'release-please--branches--main'
+        with:
+          fetch-depth: 0
+      - name: Get changed migration files
+        if: github.head_ref == 'release-please--branches--main'
+        id: changed-files
+        uses: tj-actions/changed-files@v19
+        with:
+          files: |
+            resources/provider/migrations/**/*.sql
+          base_sha: ${{ steps.latest-release.outputs.release }}
+      - name: Install dependencies
+        if: github.head_ref == 'release-please--branches--main'
+        run: |
+          npm i semver
+          npm i semver-regex@3
+      - uses: actions/github-script@v6
+        if: github.head_ref == 'release-please--branches--main'
+        env:
+          ADDED_MIGRATIONS: ${{ steps.changed-files.outputs.added_files }}
+          RELEASE_PR_TITLE: ${{ github.event.pull_request.title }}
+        with:
+          script: |
+            const { promises: fs } = require('fs');
+            const semver = require('semver');
+            const path = require('path');
+            const semverRegex = require('semver-regex');
+
+            const splitMigrationFile = (migration) => {
+              const order = parseInt(migration.split('_')[0]);
+              const versionParts = migration
+                .slice(order.length + 1)
+                .split('.')
+                .slice(0, 3);
+
+              return { order, versionParts };
+            };
+
+            const { ADDED_MIGRATIONS = '', RELEASE_PR_TITLE = '' } = process.env;
+            const migrations = ADDED_MIGRATIONS.trim().split(' ').filter(Boolean).map(migration => path.basename(migration));
+
+            if (migrations.length === 0) {
+              console.log('No migrations added. Exiting.');
+              return;
+            }
+
+            console.log(`Added migrations: ${migrations}`);
+            // 2 (up, down) for postgress, 2 (up, down) for tsdb
+            if (migrations.length !== 4) {
+              throw new Error(
+                `Please add 2 up/down migrations for postgress and 2 up/down for tsdb. Added migrations: ${migrations}`
+              );
+            }
+
+            const existingMigrations = (
+              await fs.readdir(`resources/provider/migrations/postgres`)
+            ).map(existingMigration => path.basename(existingMigration)).filter(existingMigration => !migrations.includes(existingMigration));
+
+            const latestMigration = splitMigrationFile(
+              existingMigrations[existingMigrations.length - 1]
+            );
+
+            const nextVersion = `v${semverRegex().exec(process.env.RELEASE_PR_TITLE)[0]}`;
+            console.log(`Next release is: ${nextVersion}`);
+            const expectedPrefix = `${latestMigration.order + 1}_${nextVersion}`;
+            console.log(`Expected prefix is: ${expectedPrefix}`);
+
+            const invalidMigrations = migrations.filter(
+              (migration) => !migration.startsWith(expectedPrefix)
+            );
+
+            if (invalidMigrations.length > 0) {
+              throw new Error(
+                `Invalid migrations: ${invalidMigrations.join(
+                  ', '
+                )}. Expected prefix: ${expectedPrefix}`
+              );
+            }


### PR DESCRIPTION
This PR adds validation that our migration files match our naming convention.

It works by calculation the diff from the latest release and the upcoming release (by running on the release PR branch), and ensuring any added migration files matched the expected prefix.