### PR TITLE
feat: Triage cloudquery issues

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -136,6 +136,10 @@ cloudquery/cq-provider-aws:
   - source: workflows/repo-specific/cq-provider-aws
     dest: .github/workflows/
 
+cloudquery/cloudquery-issues:
+  - source: workflows/common/issue_to_project.yml
+    dest: .github/workflows/issue_to_project.yml
+
 cloudquery/cq-provider-test:
   - source: workflows/common
     dest: .github/workflows/

--- a/workflows/common/issue_to_project.yml
+++ b/workflows/common/issue_to_project.yml
@@ -13,7 +13,7 @@ jobs:
   issue_opened_or_reopened:
     name: issue_opened_or_reopened
     runs-on: ubuntu-latest
-    if: github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    if: github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened')  && github.event.issue.user.login != 'renovate[bot]'
     steps:
       - name: Move issue to ${{ env.todo }}
         uses: leonsteinhaeuser/project-beta-automations@v1.2.1


### PR DESCRIPTION
Adds auto triage to `cloudquery-issues` repo, and also doesn't triage renovate bot issues