### PR TITLE
fix(lint): Remove only-new-issues

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -161,7 +161,7 @@ cloudquery/cq-provider-test:
     dest: .github/workflows
     exclude: |
       lint_doc.yml
-  - source: providers.golangci.yml
+  - source: misc/providers/.golangci.yml
     dest: .golangci.yml
   - source: .github/renovate.json5
     dest: .github/renovate.json5

--- a/workflows/common/lint_golang.yml
+++ b/workflows/common/lint_golang.yml
@@ -1,13 +1,12 @@
 # DONT EDIT. This file is synced from https://github.com/cloudquery/.github/.github
 name: lint_golang
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
-
-permissions:
-  contents: read
-  pull-requests: read
 
 jobs:
   golangci:
@@ -33,5 +32,3 @@ jobs:
         with:
           version: v1.46.1
           args: --timeout 5m
-          # This only works for pull request events
-          only-new-issues: true


### PR DESCRIPTION
I'm going to sweep the repos and fix any linting errors, so `only-new-issues: true` won't be needed