### PR TITLE
fix: Remove history test enforcement

### DIFF
--- a/repo-settings/cloudquery/config.yaml
+++ b/repo-settings/cloudquery/config.yaml
@@ -13,7 +13,6 @@ branchProtectionRules:
     - Lint with GolangCI
     - checks (postgres:latest, 1.17, ubuntu-latest)
     - unitests (postgres:latest, 1.17, ubuntu-latest)
-    - unitests (timescale/timescaledb:latest-pg13, 1.17, ubuntu-latest)
     - release-dry-run
     - policy-tests (postgres:latest, 1.17, ubuntu-latest, aws)
     - policy-tests (postgres:latest, 1.17, ubuntu-latest, gcp)


### PR DESCRIPTION
This enforcement is no longer required due to https://github.com/cloudquery/cloudquery/pull/769