### PR TITLE
fix(go-lint): Ignore cqproto dir

### DIFF
--- a/misc/common/.golangci.yml
+++ b/misc/common/.golangci.yml
@@ -5,6 +5,7 @@ run:
   skip-dirs:
     - bin
     - docs
+    - cqproto
 
 linters-settings:
   errcheck:


### PR DESCRIPTION
Most of that code is autogenerated 