### PR TITLE
fix: Disable nested-structs rule for providers

### DIFF
--- a/misc/providers/.golangci.yml
+++ b/misc/providers/.golangci.yml
@@ -69,6 +69,8 @@ linters-settings:
         disabled: true
       - name: flag-parameter
         disabled: true
+      - name: nested-structs
+        disabled: true
 
 linters:
   enable:


### PR DESCRIPTION
Follow up on https://github.com/cloudquery/.github/pull/132