### PR TITLE
fix: Update lint command in PR template

### DIFF
--- a/misc/common/PULL_REQUEST_TEMPLATE.md
+++ b/misc/common/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,6 @@ Use the following steps to ensure your PR is ready to be reviewed
 
 - [ ] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
 - [ ] Run `go fmt` to format your code 🖊
-- [ ] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
+- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
 - [ ] Update or add tests 🧪
 - [ ] Ensure the status checks below are successful ✅

--- a/misc/providers/PULL_REQUEST_TEMPLATE.md
+++ b/misc/providers/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Use the following steps to ensure your PR is ready to be reviewed
 
 - [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
 - [ ] Run `go fmt` to format your code 🖊
-- [ ] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
+- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
 - [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
 - [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
 - [ ] Ensure the status checks below are successful ✅

--- a/misc/providers/PULL_REQUEST_TEMPLATE_terraform.md
+++ b/misc/providers/PULL_REQUEST_TEMPLATE_terraform.md
@@ -12,7 +12,7 @@ Use the following steps to ensure your PR is ready to be reviewed
 
 - [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
 - [ ] Run `go fmt` to format your code 🖊
-- [ ] Lint your changes via `golangci-lint run --new-from-rev main` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
+- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
 - [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
 - [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
 - [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂


### PR DESCRIPTION
All the relevant lint PRs are merged so we can tell contributors to run on all the code instead of only their changes