### PR TITLE
ci: update ghaction-import-gpg to v5.0.0

### DIFF
--- a/workflows/providers/release.yml
+++ b/workflows/providers/release.yml
@@ -32,9 +32,9 @@ jobs:
           args: release --rm-dist --skip-validate --skip-publish --skip-sign
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
While attempting to use cq-provider-template to build my own
provider, I found that v3 of this action is not able to import 
signing only gpg keys. 

Upgrading to v5 and updating the argument to the new version 
allows the use of a signing only key