### PR TITLE
fix(providers-gitignore): Ignore both `cq-provider` and `cq-provider-<name>`

### DIFF
--- a/misc/providers/.gitignore
+++ b/misc/providers/.gitignore
@@ -41,4 +41,4 @@ __debug_bin
 terraform/downloaded*
 config.hcl
 terraform/tfplan.binary
-cq-provider
+cq-provider*


### PR DESCRIPTION
`make run` generates `cq-provider`
`go build` generates `cq-provider-<name>`