### PR TITLE
feat(lint): Add redundant cast check

### DIFF
--- a/misc/providers/.golangci.yml
+++ b/misc/providers/.golangci.yml
@@ -15,8 +15,11 @@ linters-settings:
     check-blank: false
     ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
   gocritic:
-    disabled-checks:
-      - commentFormatting
+    enabled-checks:
+      - ruleguard
+    settings:
+      ruleguard:
+        rules: '${configDir}/ruleguard/rules.go'
   dupl:
     # tokens count to trigger issue, 150 by default
     threshold: 500

--- a/misc/providers/ruleguard/rules.go
+++ b/misc/providers/ruleguard/rules.go
@@ -1,0 +1,12 @@
+//go:build ignore
+// +build ignore
+
+package gorules
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl"
+)
+
+func redundantCast(m dsl.Matcher) {
+	m.Match("fmt.Errorf($x, $y)").Where(m["x"].Text.Matches("expected .* but got .*")).Report("Checking for cast errors in resources is redundant")
+}


### PR DESCRIPTION
Trying to add a custom lint rule to prevent redundant casting in providers resources