### PR TITLE
fix: Send Slack notification only on push events

### DIFF
--- a/workflows/providers/test_integration.yml
+++ b/workflows/providers/test_integration.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
-        if: ${{  github.event_name != 'pull_request_target' && failure() }}
+        if: ${{  github.event_name == 'push' && failure() }}
         env:
           SLACK_CHANNEL: oss-tests
           SLACK_COLOR: ${{ job.status }}


### PR DESCRIPTION
We should send the Slack notification only if the tests failed on `main` (via push event)