### PR TITLE
fix: Cut PR template generic part from merge commit body

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -6,8 +6,11 @@ auto_approve_usernames = ["cq-bot"]
 
 [merge.message]
 body = "pull_request_body"
+cut_body_after = "Use the following steps to ensure your PR is ready to be reviewed"
+cut_body_and_text = true
+cut_body_before = "🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉"
 title = "pull_request_title"
 
 [merge.automerge_dependencies]
-versions = ["patch"]
 usernames = ["cq-bot"]
+versions = ["patch"]


### PR DESCRIPTION
See example in https://github.com/cloudquery/cloudquery/commit/9010f1808f59118f6d8803cf70b5dcb3b670d982

This change should trim the commit body to the relevant part