### PR TITLE
fix: Semantic commit types

### DIFF
--- a/workflows/common/pr_title.yml
+++ b/workflows/common/pr_title.yml
@@ -24,13 +24,9 @@ jobs:
           types: |
             fix
             feat
-            docs
-            ci
             chore
             refactor
             test
-            enhancement
-            breaking
           # Configure that a scope must always be provided.
           requireScope: false
           # Configure additional validation for the subject based on a regex.


### PR DESCRIPTION
We can use `chore(ci)` or `fix(docs)`.
For `enhancement`, `feat` should do, and we use `feat!` and `fix!` for breaking changes