### PR TITLE
fix: Revert renovate upgrade

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v32.105.0
+        uses: renovatebot/github-action@v32.103.3
         with:
           configurationFile: .github/self-hosted-renovate.json5
           token: ${{ secrets.GH_CQ_BOT }}


### PR DESCRIPTION
Trying to fix https://github.com/cloudquery/.github/runs/7175907724?check_suite_focus=true.
Renovate started failing after the latest upgrade