### PR TITLE
feat(dev): Add pre-commit hook command to makefile

### DIFF
--- a/misc/common/CONTRIBUTING.md
+++ b/misc/common/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Explain the problem and include additional details to help maintainers reproduce
 * **Describe the Bug** in as many details as possible. For example, start by explaining how and where you are running CloudQuery (local machine, cloud service, docker, k8s, CI Pipeline, etc)
 * **Provide specific examples to demonstrate the steps**. Include links to gists and or files, or copy/pasteable snippets to help give context to the issue. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines)
 * **Explain which behavior you expected to see instead and why.**
-* **Inlcude (sanitized) log output** execute CloudQuery with the `--enable-console-log` and `-v` flags to get all of the debug information
+* **Include (sanitized) log output** execute CloudQuery with the `--enable-console-log` and `-v` flags to get all of the debug information
 
 Provide more context by answering these questions:
 

--- a/misc/providers/.pre-commit-config.yaml
+++ b/misc/providers/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.0
+    hooks:
+      - id: go-mod-tidy
+      - id: golangci-lint

--- a/misc/providers/Makefile
+++ b/misc/providers/Makefile
@@ -68,3 +68,8 @@ test-integration:
 install-tools:
 	@echo Installing tools from tools/tool.go
 	@cat tools/tool.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
+
+# Install pre-commit hooks. This requires pre-commit to be installed (https://pre-commit.com/)
+.PHONY: install-hooks
+install-hooks:
+	pre-commit install


### PR DESCRIPTION
- Add a pre-commit hook command to the makefile
- Fix a typo in CONTRIBUTING.md

Instructions for the pre-commit itself seems best placed in the `development_environment.md` file, which isn't part of this repo and will need to be managed by each provider separately right now.