### PR TITLE
chore: Upgrade to Go 1.18

### DIFF
--- a/repo-settings/cloudquery/config.yaml
+++ b/repo-settings/cloudquery/config.yaml
@@ -11,10 +11,10 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - Validate PR title
     - Lint with GolangCI
-    - checks (postgres:10, 1.17, ubuntu-latest)
-    - unitests (postgres:10, 1.17, ubuntu-latest)
+    - checks (postgres:10, 1.18, ubuntu-latest)
+    - unitests (postgres:10, 1.18, ubuntu-latest)
     - release-dry-run
-    - policy-tests (postgres:10, 1.17, ubuntu-latest, aws)
-    - policy-tests (postgres:10, 1.17, ubuntu-latest, gcp)
-    - policy-tests (postgres:10, 1.17, ubuntu-latest, azure)
-    - policy-tests (postgres:10, 1.17, ubuntu-latest, k8s)
+    - policy-tests (postgres:10, 1.18, ubuntu-latest, aws)
+    - policy-tests (postgres:10, 1.18, ubuntu-latest, gcp)
+    - policy-tests (postgres:10, 1.18, ubuntu-latest, azure)
+    - policy-tests (postgres:10, 1.18, ubuntu-latest, k8s)

--- a/repo-settings/cq-provider-sdk/config.yaml
+++ b/repo-settings/cq-provider-sdk/config.yaml
@@ -11,4 +11,4 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - Validate PR title
     - Lint with GolangCI
-    - unitests (postgres:10, 1.17, ubuntu-latest)
+    - unitests (postgres:10, 1.18, ubuntu-latest)

--- a/repo-settings/providers/config.yaml
+++ b/repo-settings/providers/config.yaml
@@ -12,6 +12,6 @@ branchProtectionRules:
     - Validate PR title
     - Lint with GolangCI
     - Lint Provider Doc
-    - test_unit (postgres:10, 1.17, ubuntu-latest)
+    - test_unit (postgres:10, 1.18, ubuntu-latest)
     - release-dry-run
-    - test_integration (postgres:10, 1.17, ubuntu-latest)
+    - test_integration (postgres:10, 1.18, ubuntu-latest)

--- a/repo-settings/providers/k8s/config.yaml
+++ b/repo-settings/providers/k8s/config.yaml
@@ -12,5 +12,5 @@ branchProtectionRules:
     - Validate PR title
     - Lint with GolangCI
     - Lint Provider Doc
-    - test_unit (postgres:10, 1.17, ubuntu-latest)
+    - test_unit (postgres:10, 1.18, ubuntu-latest)
     - release-dry-run

--- a/repo-settings/providers/no-integration-tests/config.yaml
+++ b/repo-settings/providers/no-integration-tests/config.yaml
@@ -12,5 +12,5 @@ branchProtectionRules:
     - Validate PR title
     - Lint with GolangCI
     - Lint Provider Doc
-    - test_unit (postgres:10, 1.17, ubuntu-latest)
+    - test_unit (postgres:10, 1.18, ubuntu-latest)
     - release-dry-run

--- a/repo-settings/providers/with-terraform-tests/config.yaml
+++ b/repo-settings/providers/with-terraform-tests/config.yaml
@@ -12,7 +12,7 @@ branchProtectionRules:
     - Validate PR title
     - Lint with GolangCI
     - Lint Provider Doc
-    - test_unit (postgres:10, 1.17, ubuntu-latest)
+    - test_unit (postgres:10, 1.18, ubuntu-latest)
     - release-dry-run
-    - test_integration (postgres:10, 1.17, ubuntu-latest)
+    - test_integration (postgres:10, 1.18, ubuntu-latest)
     - Terrafrom Plan

--- a/workflows/common/lint_golang.yml
+++ b/workflows/common/lint_golang.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-go@v3
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: golangci-lint
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'

--- a/workflows/providers/lint_doc.yml
+++ b/workflows/providers/lint_doc.yml
@@ -24,7 +24,7 @@ jobs:
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: ^1.18
       - uses: actions/cache@v3
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
         with:

--- a/workflows/providers/release.yml
+++ b/workflows/providers/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser Dry-Run
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/workflows/providers/terraform_apply.yml
+++ b/workflows/providers/terraform_apply.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: ^1.18
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/workflows/providers/terraform_plan.yml
+++ b/workflows/providers/terraform_plan.yml
@@ -65,7 +65,7 @@ jobs:
         if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request_target'
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: ^1.18
 
       <%> auth_step %>
 

--- a/workflows/providers/test_integration.yml
+++ b/workflows/providers/test_integration.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         dbversion: [ "postgres:10" ]
-        go: [ "1.17" ]
+        go: [ "1.18" ]
         platform: [ ubuntu-latest ] # can not run in macOS and windowsOS
     runs-on: ${{ matrix.platform }}
     services:

--- a/workflows/providers/test_unit.yml
+++ b/workflows/providers/test_unit.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ["postgres:10"]
-        go: ["1.17"]
+        go: ["1.18"]
         platform: [ubuntu-latest] # can not run in macOS and windowsOS
     runs-on: ${{ matrix.platform }}
     services:

--- a/workflows/providers/validate_release.yml
+++ b/workflows/providers/validate_release.yml
@@ -20,7 +20,7 @@ jobs:
         if: startsWith(github.head_ref, 'release')
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run GoReleaser Dry-Run
         if: startsWith(github.head_ref, 'release')
         uses: goreleaser/goreleaser-action@v3

--- a/workflows/repo-specific/cloudquery/release.yml
+++ b/workflows/repo-specific/cloudquery/release.yml
@@ -27,7 +27,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       -
         name: Run GoReleaser Dry-Run

--- a/workflows/repo-specific/cloudquery/sanity.yml
+++ b/workflows/repo-specific/cloudquery/sanity.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['postgres:10']
-        go: ['1.17']
+        go: ['1.18']
         platform: [ ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     services:

--- a/workflows/repo-specific/cloudquery/test.yml
+++ b/workflows/repo-specific/cloudquery/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['postgres:10']
-        go: ['1.17']
+        go: ['1.18']
         platform: [ ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     services:

--- a/workflows/repo-specific/cloudquery/validate_release.yml
+++ b/workflows/repo-specific/cloudquery/validate_release.yml
@@ -22,7 +22,7 @@ jobs:
         if: startsWith(github.head_ref, 'release')
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       -
         name: Run GoReleaser Dry-Run
         if: startsWith(github.head_ref, 'release')

--- a/workflows/repo-specific/cq-provider-aws/endpoints.yml
+++ b/workflows/repo-specific/cq-provider-aws/endpoints.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version: ^1.18
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}

--- a/workflows/repo-specific/cq-provider-sdk/unittest.yml
+++ b/workflows/repo-specific/cq-provider-sdk/unittest.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         dbversion: ['postgres:10']
-        go: ['1.17']
+        go: ['1.18']
         platform: [ ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     services:


### PR DESCRIPTION
This upgrades the common files to Go 1.18. 

Relates to https://github.com/cloudquery/cloudquery/issues/1147