### PR TITLE
chore: Add cq-gen drift detection workflow

### DIFF
--- a/workflows/providers/check_generated_code_drift.yml
+++ b/workflows/providers/check_generated_code_drift.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - check-cq-gen
     paths:
       - 'resources/services/**/*'
   pull_request:

--- a/workflows/providers/check_generated_code_drift.yml
+++ b/workflows/providers/check_generated_code_drift.yml
@@ -1,0 +1,63 @@
+# DO NOT EDIT. This file is synced from https://github.com/cloudquery/.github/.github
+name: check_generated_code_drift
+on:
+  push:
+    branches:
+      - main
+      - check-cq-gen
+    paths:
+      - 'resources/services/**/*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'resources/services/**/*'
+jobs:
+  lint_doc:
+    name: Check Generated Code for Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'resources/services/**/*'
+      - name: Set up Go 1.x
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.18
+      - name: Install tools
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        run: |
+          make install-tools
+      - uses: actions/cache@v3
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          # * Build cache (Mac)
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go }}-
+      - name: Run go generate on changed service directories
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        run: |
+          ./scripts/regenerate-changed-directories.sh
+      - name: Fail if any files are changed
+        if: steps.changes.outputs.src == 'true' || github.event_name != 'pull_request'
+        run: |
+          echo "List of files changed after running go generate:"
+          git status -s ./resources/services
+          test "$(git status -s ./resources/services | wc -l)" -eq 0

--- a/workflows/scripts/regenerate-changed-directories.sh
+++ b/workflows/scripts/regenerate-changed-directories.sh
@@ -1,0 +1,15 @@
+set -x
+set -e
+
+for d in ./resources/services/*/ ; do
+  # check whether directory changed in this branch
+  if git diff --quiet origin/main HEAD -- $d; then
+    echo "no changes in $d";
+    continue;
+  fi
+
+  # regenerate if //check-for-changes is present in an .hcl file
+  if grep -s -q '//check-for-changes' "$d"*.hcl; then
+   (cd $d && go generate);
+  fi
+done


### PR DESCRIPTION
This adds a workflow to check that generated files do not drift from their definitions. Since this check would fail on many different services right now, it is introduced with a feature flag: only directories containing an .hcl file marked with `//check-for-changes` will be checked. 

Since regeneration is also fairly slow, we only do this on changed resource directories. And if no resource directories changed, the action is completely skipped.

You can see the action being tested on the AWS provider here: https://github.com/cloudquery/cq-provider-aws/pull/1390