### PR TITLE
fix(renovate): Use go mod tidy instead of compat=1.17

### DIFF
--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -1,6 +1,6 @@
 {
   extends: ["github>cloudquery/.github//.github/renovate-default.json5"],
-  postUpdateOptions: ["gomodTidy1.17"],
+  postUpdateOptions: ["gomodTidy"],
   packageRules: [
     { matchManagers: ["gomod"], enabled: true },
     {

--- a/misc/providers/.pre-commit-config.yaml
+++ b/misc/providers/.pre-commit-config.yaml
@@ -2,5 +2,5 @@ repos:
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.0
     hooks:
-      # - id: go-mod-tidy
+      - id: go-mod-tidy
       - id: golangci-lint


### PR DESCRIPTION
Brings back https://github.com/cloudquery/.github/pull/265

cc @bbernays and @hermanschaaf.

Now that we've upgraded to Go 1.18 we don't need `gomodTidy1.17` and can use `gomodTidy` as the dependency graph between 1.17 and 1.18 should be the same (not the case for 1.16 and 1.17`).
See more here https://stackoverflow.com/questions/71973152/go-mod-tidy-error-message-but-go-1-16-would-select
