### PR TITLE
chore: Group linter and go versions updates

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -34,6 +34,7 @@
   packageRules: [
     { matchManagers: ["regex"], addLabels: ["no automerge"], commitMessagePrefix: "chore(deps): " },
     { matchManagers: ["github-actions"], groupName: "github-actions", commitMessagePrefix: "chore(deps): " },
+    { matchPackageNames: ["go", "golangci/golangci-lint"], groupName: "go version and linter" },
     {
       matchManagers: ["github-actions"],
       matchPackageNames: ["postgres"],


### PR DESCRIPTION
Usually updating our linter or go version must be done together, see:
https://github.com/cloudquery/plugin-sdk/pull/37
https://github.com/cloudquery/plugin-sdk/pull/36

This should group these updates to a single PR