### PR TITLE
fix(renovate): Don't run gofmt after go updates

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -46,12 +46,13 @@
       matchPackageNames: ["go", "golangci/golangci-lint"],
       groupName: "go version and linter",
     },
-    {
-      matchPackageNames: ["go"],
-      postUpgradeTasks: {
-        commands: ["gofmt -s -w ."],
-      },
-    },
+    // TODO: Enable when https://github.com/renovatebot/github-action/issues/625 is fixed
+    // {
+    //   matchPackageNames: ["go"],
+    //   postUpgradeTasks: {
+    //     commands: ["gofmt -s -w ."],
+    //   },
+    // },
     {
       matchManagers: ["github-actions"],
       matchPackageNames: ["postgres"],

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,9 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '>=1.18'
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v32.185.3
         with:


### PR DESCRIPTION
The renovate GitHub actions runs renovate in a docker container so we can't install tools like `gofmt`.

We should wait for https://github.com/renovatebot/github-action/issues/625 to use the renovate non slim image that has `gofmt` pre-installed