### PR TITLE
chore: Improve dependencies automerge

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -13,7 +13,6 @@ title = "pull_request_title"
 
 [merge.automerge_dependencies]
 usernames = ["cq-bot"]
-versions = ["minor", "patch"]
 
 [merge]
 blocking_labels = ["wip", "no automerge"]

--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -33,8 +33,11 @@
   ],
   packageRules: [
     {
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      addLabels: ["automerge"],
+    },
+    {
       matchManagers: ["regex"],
-      addLabels: ["no automerge"],
       commitMessagePrefix: "chore(deps): ",
     },
     {
@@ -46,13 +49,6 @@
       matchPackageNames: ["go", "golangci/golangci-lint"],
       groupName: "go version and linter",
     },
-    // TODO: Enable when https://github.com/renovatebot/github-action/issues/625 is fixed
-    // {
-    //   matchPackageNames: ["go"],
-    //   postUpgradeTasks: {
-    //     commands: ["gofmt -s -w ."],
-    //   },
-    // },
     {
       matchManagers: ["github-actions"],
       matchPackageNames: ["postgres"],


### PR DESCRIPTION
Improves dependencies auto merge to support `digest` (common in `go` modules). Kodiak only supports SemVer based updates, so we use renovate logic to add the `automerge` label