### PR TITLE
chore(deps): Split SDK PRs

### DIFF
--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -8,5 +8,9 @@
       enabled: true,
       schedule: ["at any time"],
     },
+    {
+      matchPackagePatterns: ["github.com/cloudquery/plugin-sdk"],
+      additionalBranchPrefix: "{{baseDir}}-",
+    },
   ],
 }


### PR DESCRIPTION
This should break the SDK updates into a PR per plugin, so a single failure doesn't block all plugins.
An example is https://github.com/cloudquery/cloudquery/pull/2203 where the only breakage is for destination plugins, but all updates are blocked