### PR TITLE
chore: Run renovate every hour instead of every 15 minutes

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0/15 * * * *'
+    - cron: '0 * * * *'
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
With https://github.com/cloudquery/plugin-sdk/pull/266, running on every hour should be enough