### PR TITLE
fix(renovate): Update dependencies for test plugins

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -1,7 +1,7 @@
 {
   extends: ["config:base", "schedule:monthly"],
   rebaseWhen: "conflicted",
-  ignorePresets: [":prHourlyLimit2"],
+  ignorePresets: [":prHourlyLimit2", ":ignoreModulesAndTests"],
   automerge: false,
   semanticCommits: false,
   commitMessagePrefix: "fix(deps): ",


### PR DESCRIPTION
This ignores https://docs.renovatebot.com/presets-default/#ignoremodulesandtests which is a part of the base preset, but results in our test plugins not being updated in the monorepo