### PR TITLE
chore: Don't automerge all helm charts updates

### DIFF
--- a/.github/renovate-terraform.json5
+++ b/.github/renovate-terraform.json5
@@ -21,7 +21,6 @@
       extractVersion: "^cloudquery\\-(?<version>.+)$",
       schedule: ["at any time"],
       commitMessagePrefix: "fix(deps): ",
-      labels: ["automerge"],
     },
   ],
 }


### PR DESCRIPTION
Auto merging should be based on the version bump type as in https://github.com/cloudquery/.github/blob/6502a3c049cb4591ce3b6adeb962b932081b535c/.github/renovate-default.json5#L36