### PR TITLE
chore(deps): Auto update examples in terraform repositories

### DIFF
--- a/.github/renovate-terraform.json5
+++ b/.github/renovate-terraform.json5
@@ -7,6 +7,7 @@
       depNameTemplate: "cloudquery/helm-charts",
       datasourceTemplate: "github-releases",
       versioningTemplate: "loose",
+      extractVersionTemplate: "^cloudquery\\-(?<version>.+)$",
     },
     {
       fileMatch: ["^.github/workflows/.+.ya?ml$"],
@@ -14,11 +15,46 @@
       depNameTemplate: "terraform-docs/terraform-docs",
       datasourceTemplate: "github-releases",
     },
+    {
+      fileMatch: ["^examples/complete/config.yml$"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of aws plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-source-aws-(?<version>.+)$",
+    },
+    {
+      fileMatch: ["^examples/complete/config.yml$"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of azure plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-source-azure-(?<version>.+)$",
+    },
+    {
+      fileMatch: ["^examples/complete/config.yml$"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of gcp plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-source-gcp-(?<version>.+)$",
+    },
+    {
+      fileMatch: ["^examples/complete/config.yml$"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of postgresql plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-destination-postgresql-(?<version>.+)$",
+    },
   ],
   packageRules: [
     {
       matchPackageNames: ["cloudquery/helm-charts"],
-      extractVersion: "^cloudquery\\-(?<version>.+)$",
       schedule: ["at any time"],
       commitMessagePrefix: "fix(deps): ",
     },


### PR DESCRIPTION
Ensures we update the examples in the Terraform repos:
https://github.com/cloudquery/terraform-aws-cloudquery/blob/df4ab1e70f14bdff03a3d658a8064d1c4711762f/examples/complete/config.yml
https://github.com/cloudquery/terraform-gcp-cloudquery/blob/16d872fd0d9015bf78610af6b46b7e28233a7bc4/examples/complete/config.yml
https://github.com/cloudquery/terraform-azure-cloudquery/blob/57f98110e139777db47bd5d84c761f2b323ae2f7/examples/complete/config.yml