### PR TITLE
chore(deps): Update plugin versions in configs in all repos

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -30,6 +30,42 @@
       datasourceTemplate: "golang-version",
       versioningTemplate: "loose",
     },
+    {
+      fileMatch: ["*.yml", "*.yaml"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of aws plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-source-aws-(?<version>.+)$",
+    },
+    {
+      fileMatch: ["*.yml", "*.yaml"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of azure plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-source-azure-(?<version>.+)$",
+    },
+    {
+      fileMatch: ["*.yml", "*.yaml"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of gcp plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-source-gcp-(?<version>.+)$",
+    },
+    {
+      fileMatch: ["*.yml", "*.yaml"],
+      matchStrings: [
+        'version: "(?<currentValue>.*)" # latest version of postgresql plugin',
+      ],
+      depNameTemplate: "cloudquery/cloudquery",
+      datasourceTemplate: "github-releases",
+      extractVersionTemplate: "^plugins-destination-postgresql-(?<version>.+)$",
+    },
   ],
   packageRules: [
     {
@@ -53,6 +89,12 @@
       matchManagers: ["github-actions"],
       matchPackageNames: ["postgres"],
       allowedVersions: ["11"],
+    },
+    {
+      matchPackagePatterns: ["github.com/cloudquery/*"],
+      enabled: true,
+      schedule: ["at any time"],
+      commitMessagePrefix: "fix(deps): ",
     },
   ],
 }

--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -4,11 +4,6 @@
   packageRules: [
     { matchManagers: ["gomod"], enabled: true },
     {
-      matchPackagePatterns: ["github.com/cloudquery/*"],
-      enabled: true,
-      schedule: ["at any time"],
-    },
-    {
       matchPackagePatterns: ["github.com/cloudquery/plugin-sdk"],
       additionalBranchPrefix: "{{baseDir}}-",
       commitMessageTopic: "plugin-sdk for {{parentDir}}",

--- a/.github/renovate-terraform.json5
+++ b/.github/renovate-terraform.json5
@@ -15,48 +15,5 @@
       depNameTemplate: "terraform-docs/terraform-docs",
       datasourceTemplate: "github-releases",
     },
-    {
-      fileMatch: ["^examples/complete/config.yml$"],
-      matchStrings: [
-        'version: "(?<currentValue>.*)" # latest version of aws plugin',
-      ],
-      depNameTemplate: "cloudquery/cloudquery",
-      datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^plugins-source-aws-(?<version>.+)$",
-    },
-    {
-      fileMatch: ["^examples/complete/config.yml$"],
-      matchStrings: [
-        'version: "(?<currentValue>.*)" # latest version of azure plugin',
-      ],
-      depNameTemplate: "cloudquery/cloudquery",
-      datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^plugins-source-azure-(?<version>.+)$",
-    },
-    {
-      fileMatch: ["^examples/complete/config.yml$"],
-      matchStrings: [
-        'version: "(?<currentValue>.*)" # latest version of gcp plugin',
-      ],
-      depNameTemplate: "cloudquery/cloudquery",
-      datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^plugins-source-gcp-(?<version>.+)$",
-    },
-    {
-      fileMatch: ["^examples/complete/config.yml$"],
-      matchStrings: [
-        'version: "(?<currentValue>.*)" # latest version of postgresql plugin',
-      ],
-      depNameTemplate: "cloudquery/cloudquery",
-      datasourceTemplate: "github-releases",
-      extractVersionTemplate: "^plugins-destination-postgresql-(?<version>.+)$",
-    },
-  ],
-  packageRules: [
-    {
-      matchPackageNames: ["cloudquery/helm-charts"],
-      schedule: ["at any time"],
-      commitMessagePrefix: "fix(deps): ",
-    },
   ],
 }


### PR DESCRIPTION
We reference plugins version in many repos:

https://github.com/cloudquery/helm-charts/blob/4a4c8ae89d66714f5d57ef77b9f573847587b0d2/charts/cloudquery/values.yaml#L71
https://github.com/cloudquery/setup-cloudquery/blob/af927fe428033bf187208b036e6c2c9dbcede6cb/example_configs/aws.yml#L4
https://github.com/cloudquery/terraform-aws-cloudquery/blob/6b71f2dd365ea76ce862392f44be389518b01bae/examples/complete/config.yml#L5

And more.

This PR ensures we update the plugins version in all relevant `yml` files