### PR TITLE
chore: Schedule CloudQuery updates for Helm-Charts at any time

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -91,7 +91,7 @@
       allowedVersions: ["11"],
     },
     {
-      matchPackagePatterns: ["github.com/cloudquery/*"],
+      matchPackagePatterns: ["github.com/cloudquery/*", "cloudquery/cloudquery"],
       enabled: true,
       schedule: ["at any time"],
       commitMessagePrefix: "fix(deps): ",


### PR DESCRIPTION
This is need due to the way `regex` matchers work:

https://github.com/cloudquery/.github/blob/cee4f3b57cd34306f9e9d9d5e8603cacca3f806b/.github/renovate-default.json5#L56