### PR TITLE
chore(deps): Set `prConcurrentLimit` to 20

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -5,6 +5,7 @@
   automerge: false,
   semanticCommits: false,
   commitMessagePrefix: "fix(deps): ",
+  prConcurrentLimit: 20,
   vulnerabilityAlerts: {
     enabled: true,
     labels: ["security"],


### PR DESCRIPTION
This should allow all SDK updates to be opened at the same time (we have more than 10 plugins) which is the current limit of PRs in `config:base`