### PR TITLE
chore(deps): Set cloudquery updates to fix only for helm charts and terraform repos

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -92,7 +92,7 @@
       allowedVersions: ["11"],
     },
     {
-      matchPackagePatterns: ["github.com/cloudquery/*", "cloudquery/*"],
+      matchPackagePatterns: ["github.com/cloudquery/*"],
       enabled: true,
       schedule: ["at any time"],
       commitMessagePrefix: "fix(deps): ",

--- a/.github/renovate-terraform.json5
+++ b/.github/renovate-terraform.json5
@@ -16,4 +16,10 @@
       datasourceTemplate: "github-releases",
     },
   ],
+  packageRules: [
+    {
+      matchPackagePatterns: ["cloudquery/helm-charts"],
+      commitMessagePrefix: "fix(deps): ",
+    },
+  ],
 }


### PR DESCRIPTION
Should make https://github.com/cloudquery/cloudquery/pull/3830 into a `chore:` instead of a `fix:`

Goes with https://github.com/cloudquery/helm-charts/pull/171