### PR TITLE
fix(deps): Match golangci-lint in all GitHub Actions

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -13,7 +13,7 @@
   },
   regexManagers: [
     {
-      fileMatch: ["^.github/workflows/lint_golang.yml$"],
+      fileMatch: ["^.github/workflows/.+.ya?ml$"],
       matchStrings: [
         "golangci\\-lint\\-action[\\s\\S]+?version\\: (?<currentValue>.*)",
       ],


### PR DESCRIPTION
This should fix support for updating our linter