### PR TITLE
fix(deps): CloudQuery renovate schedule

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -116,12 +116,12 @@
       allowedVersions: ["11"],
     },
     {
-      matchPackagePatterns: ["github.com/cloudquery/*", "cloudquery/*"],
+      matchSourceUrlPrefixes: ["https://github.com/cloudquery/"],
       enabled: true,
       schedule: ["at any time"],
     },
     {
-      matchPackagePatterns: ["cloudquery/cloudquery"],
+      matchSourceUrls: ["https://github.com/cloudquery/cloudquery"],
       groupName: "CloudQuery monorepo modules",
     },
   ],


### PR DESCRIPTION
This is needed due to https://github.com/cloudquery/.github/pull/381 where I changed the naming convention of the monorepo packages