### PR TITLE
chore: Don't group Go and Linter updates

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -107,10 +107,6 @@
       commitMessagePrefix: "chore(deps): ",
     },
     {
-      matchPackageNames: ["go", "golangci/golangci-lint"],
-      groupName: "go version and linter",
-    },
-    {
       matchManagers: ["github-actions"],
       matchPackageNames: ["postgres"],
       allowedVersions: ["11"],


### PR DESCRIPTION
We don't need this anymore (we only did this since a specific version of the linter required a specific version of Go)