### PR TITLE
feat(deps): Update go version in go.mod files

### DIFF
--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -4,6 +4,10 @@
   packageRules: [
     { matchManagers: ["gomod"], enabled: true },
     {
+      matchDatasources: ["golang-version"],
+      rangeStrategy: "bump",
+    },
+    {
       matchPackagePatterns: ["github.com/aws/*"],
       schedule: ["before 3am on Monday"],
     },


### PR DESCRIPTION
See https://docs.renovatebot.com/modules/versioning/#go-modules-directive-versioning

The default is not to bump Go version