### PR TITLE
fix: Update AWS dependencies schedule

### DIFF
--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -13,7 +13,7 @@
     },
     {
       matchPackagePatterns: ["github.com/aws/*"],
-      schedule: ["before 3am on Monday"],
+      schedule: ["before 3am on Saturday"],
     },
   ],
 }


### PR DESCRIPTION
This should ensure the AWS dependencies PRs use the CI resources when no one is around