### PR TITLE
fix: Update arrow only once per week

### DIFF
--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -16,6 +16,10 @@
       schedule: ["before 3am on Saturday"],
     },
     {
+      matchPackagePatterns: ["github.com/cloudquery/arrow/*"],
+      schedule: ["before 3am on Monday"],
+    },
+    {
       matchPackagePatterns: ["github.com/marcboeker/go-duckdb"],
       schedule: null,
     },


### PR DESCRIPTION
These updates are a bit noisy at the moment as they happen on each new commit to the Arrow repository