### PR TITLE
fix(deps): Fix arrow schedule

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -118,6 +118,10 @@
       schedule: ["at any time"],
     },
     {
+      matchPackagePatterns: ["github.com/cloudquery/arrow/*"],
+      schedule: ["before 3am on Monday"],
+    },
+    {
       matchSourceUrls: ["https://github.com/cloudquery/cloudquery"],
       groupName: "CloudQuery monorepo modules",
     },

--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -16,10 +16,6 @@
       schedule: ["before 3am on Saturday"],
     },
     {
-      matchPackagePatterns: ["github.com/cloudquery/arrow/*"],
-      schedule: ["before 3am on Monday"],
-    },
-    {
       matchPackagePatterns: ["github.com/marcboeker/go-duckdb"],
       schedule: null,
     },


### PR DESCRIPTION
Moving this to the default configuration to avoid any ordering issues if someone imports both the `node` preset and the `go` preset. Our monorepo does it and the `node` preset overrides the `go` one