### PR TITLE
fix: Group AWS updates per plugin

### DIFF
--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -15,6 +15,7 @@
       matchPackagePatterns: ["github.com/aws/*"],
       schedule: ["before 3am on Saturday"],
       groupName: "AWS modules",
+      additionalBranchPrefix: "{{parentDir}}-",
     },
     {
       matchPackagePatterns: ["github.com/marcboeker/go-duckdb"],


### PR DESCRIPTION
Follow up to https://github.com/cloudquery/.github/pull/410.

This ensures we group AWS module updates into a single PR **per plugin** in the monorepo, instead of a single PR for all plugins

More in https://docs.renovatebot.com/configuration-options/#additionalbranchprefix