### PR TITLE
Add `no automerge` label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,5 +1,9 @@
 - name: automerge
+  description: Automatically merge once required checks pass
   color: 0E8A16
+- name: no automerge
+  description: Block automatic merging
+  color: F0F008
 - name: good-first-issue
   color: 7057ff
 - name: needs-triage


### PR DESCRIPTION
We might also need to add the label to blockers for Kodiaq