### PR TITLE
chore: Revert Java config change

### DIFF
--- a/.github/renovate-java-default.json5
+++ b/.github/renovate-java-default.json5
@@ -3,7 +3,4 @@
   java: {
     enabled: true,
   },
-  packageRules: [
-    { matchPackagePatterns: ["^io.cloudquery"], schedule: ["at any time"] },
-  ],
 }


### PR DESCRIPTION
Not sure why but it seems https://github.com/cloudquery/.github/commit/947d952c75a20343a3c872ba9fd3cbdffd34d77e is causing renovate to run super slow so I'm reverting it

![image](https://github.com/cloudquery/.github/assets/26760571/a0632b22-f123-41cb-81e7-eecae0cc564b)

If this doesn't work probably something changed on renovate's side