### PR TITLE
chore: Disable renovate request limits

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v40.1.2
         with:
-          renovate-version: "37"
+          renovate-version: "37.227.2"
           configurationFile: .github/self-hosted-renovate.js
           token: ${{ secrets.GH_CQ_BOT }}
         env:


### PR DESCRIPTION
I think https://github.com/renovatebot/renovate/pull/27621 caused our renovate workflow to run significantly slower (about 2 hours instead of 10 minutes) so trying to use an earlier version