### PR TITLE
chore: Use latest v37 version

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v40.1.2
         with:
-          renovate-version: "37.227.2"
+          renovate-version: "37"
           configurationFile: .github/self-hosted-renovate.js
           token: ${{ secrets.GH_CQ_BOT }}
         env:


### PR DESCRIPTION
Now that https://github.com/renovatebot/renovate/discussions/27759 is fixed we can move to the latest v37 version again