### PR TITLE
chore: Don't allow docker v27 versions

### DIFF
--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -37,6 +37,10 @@
       additionalBranchPrefix: "{{parentDir}}-",
     },
     {
+      matchPackageNames: ["github.com/docker/docker"],
+      allowedVersions: "<27",
+    },
+    {
       matchPackagePatterns: ["github.com/marcboeker/go-duckdb"],
       schedule: null,
     },


### PR DESCRIPTION
Should help with https://github.com/cloudquery/cloudquery-issues/issues/2041 until v27 is stable