### PR TITLE
chore: Group eslint updates

### DIFF
--- a/.github/renovate-node-default.json5
+++ b/.github/renovate-node-default.json5
@@ -3,5 +3,11 @@
   packageRules: [
     { matchManagers: ["npm"], enabled: true },
     { matchPackagePatterns: ["^@cloudquery/"], schedule: ["at any time"] },
+    {
+      matchManagers: ["npm"],
+      matchPackagePatterns: ["eslint"],
+      groupName: "eslint packages",
+      additionalBranchPrefix: "{{parentDir}}-",
+    },
   ],
 }


### PR DESCRIPTION
Should help with errors like this
https://github.com/cloudquery/cloudquery/pull/19763

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: @cloudquery/cq-source-airtable@2.2.10
npm error Found: eslint@8.57.1
npm error node_modules/eslint
npm error   dev eslint@"^8.46.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer eslint@">=9" from eslint-plugin-ava@15.0.1
npm error node_modules/eslint-plugin-ava
npm error   dev eslint-plugin-ava@"^15.0.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /tmp/renovate/cache/others/npm/_logs/2024-11-29T09_28_12_224Z-eresolve-report.txt
npm error A complete log of this run can be found in: /tmp/renovate/cache/others/npm/_logs/2024-11-29T09_28_12_224Z-debug-0.log

```