### PR TITLE
chore: Remove CLI and plugins update grouping

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -155,9 +155,5 @@
       matchDatasources: ["custom.cloudquery"],
       groupName: "CloudQuery monorepo modules",
     },
-    {
-      matchSourceUrls: ["https://github.com/cloudquery/cloudquery"],
-      groupName: "CloudQuery monorepo modules",
-    },
   ],
 }


### PR DESCRIPTION
This rule groups CLI and plugins update together which is not always desired.
Plugins are still grouped via https://github.com/cloudquery/.github/blob/6f4719b95313b4949ea3a6a00a00d2850cf079a6/.github/renovate-default.json5#L155