### PR TITLE
chore: Revert "chore: Don't allow docker v27 versions"

### DIFF
--- a/.github/renovate-go-default.json5
+++ b/.github/renovate-go-default.json5
@@ -36,10 +36,6 @@
       additionalBranchPrefix: "{{parentDir}}-",
     },
     {
-      matchPackageNames: ["github.com/docker/docker"],
-      allowedVersions: "<27",
-    },
-    {
       matchPackagePatterns: ["github.com/marcboeker/go-duckdb"],
       schedule: null,
     },


### PR DESCRIPTION
Reverts cloudquery/.github#464

The [related bugs](https://github.com/cloudquery/cloudquery-issues/issues/2041#issuecomment-2233738983) that kept us from updating have been fixed.

Let's try and update again