### PR TITLE
chore: Fix PR title for major GitHub Actions updates

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -132,6 +132,11 @@
     },
     {
       matchManagers: ["github-actions"],
+      matchUpdateTypes: ["major"],
+      commitMessagePrefix: "chore(deps): ",
+    },
+    {
+      matchManagers: ["github-actions"],
       matchPackageNames: ["postgres"],
       allowedVersions: ["11"],
     },


### PR DESCRIPTION
Example of PR that should be a `chore:` 
<img width="904" height="496" alt="image" src="https://github.com/user-attachments/assets/2edbc9e9-0822-4ad9-b587-52b8b0670e1e" />
