### PR TITLE
chore: Increase PR concurrent limit from 200 to 500

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -5,7 +5,7 @@
   automerge: false,
   semanticCommits: false,
   commitMessagePrefix: "fix(deps): ",
-  prConcurrentLimit: 200,
+  prConcurrentLimit: 500,
   minimumReleaseAge: "7 days",
   vulnerabilityAlerts: {
     enabled: true,


### PR DESCRIPTION
Looks like with 200 we're lagging behind updates for some repos