### PR TITLE
chore: Add prHourlyLimit to Renovate configuration

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -5,6 +5,7 @@
   automerge: false,
   semanticCommits: false,
   commitMessagePrefix: "fix(deps): ",
+  prHourlyLimit: 50,
   prConcurrentLimit: 500,
   minimumReleaseAge: "7 days",
   vulnerabilityAlerts: {


### PR DESCRIPTION
Follow up to https://github.com/cloudquery/.github/pull/499.

This is more suitable for us since we have a few monorepos, and many components per repo