### PR TITLE
chore: Change runner from ubuntu-latest to ubicloud-standard-4

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-4
     timeout-minutes: 180
     steps:
       - name: Checkout


### PR DESCRIPTION
The GitHub runner is costing us $146.24 per month. We can use a stronger Ubicloud version of pay x5 less.