### PR TITLE
chore: Change Renovate schedule to run every 2 hours

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -2,7 +2,7 @@ name: Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */2 * * *"
 
 concurrency:
   group: renovate-main


### PR DESCRIPTION
The runs are getting longer and often newer runs cancel existing ones, also because we trigger some runs manually
<img width="1499" height="1113" alt="image" src="https://github.com/user-attachments/assets/763966d7-ac5e-4436-b8cb-27ccb35ab66c" />
