### PR TITLE
chore: Use workspace-relative path for Renovate cache

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Renovate cache
         uses: actions/cache@v5
         with:
-          path: /tmp/renovate/cache
+          path: ${{ github.workspace }}/.renovate-cache
           key: renovate-cache-${{ env.RENOVATE_VERSION }}-${{ github.run_id }}
           restore-keys: |
             renovate-cache-${{ env.RENOVATE_VERSION }}-
@@ -37,4 +37,5 @@ jobs:
         env:
           RENOVATE_GITHUB_ACTOR: ${{ github.actor }}
           RENOVATE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RENOVATE_CACHE_DIR: ${{ github.workspace }}/.renovate-cache
           LOG_LEVEL: 'debug'


### PR DESCRIPTION
Should fix https://github.com/cloudquery/.github/actions/runs/23255174641/job/67624625722#step:5:573 

```
DEBUG: Deleted 0 of 4078 file cached entries in 2715ms
 INFO: Renovate is exiting with a non-zero code due to the following logged errors
       "loggerErrors": [
         {
           "name": "renovate",
           "level": 60,
           "logContext": "b592ff04-8b40-4d37-bc9f-110524871507",
           "err": {
             "errno": -13,
             "code": "EACCES",
             "syscall": "mkdir",
             "path": "/tmp/renovate/repos",
             "message": "EACCES: permission denied, mkdir '/tmp/renovate/repos'",
             "stack": "Error: EACCES: permission denied, mkdir '/tmp/renovate/repos'"
           },
           "msg": "Unknown error"
         }
       ]
```