### PR TITLE
chore: Pin GitHub Actions to commit SHAs to prevent supply chain attacks

### DIFF
--- a/.github/renovate-default.json5
+++ b/.github/renovate-default.json5
@@ -1,5 +1,5 @@
 {
-  extends: ["config:recommended", "schedule:monthly"],
+  extends: ["config:recommended", "schedule:monthly", "helpers:pinGitHubActionDigests"],
   rebaseWhen: "conflicted",
   ignorePresets: [":prHourlyLimit2", ":ignoreModulesAndTests"],
   automerge: false,


### PR DESCRIPTION
Add `helpers:pinGitHubActionDigests` Renovate preset to automatically pin all GitHub Actions to commit SHAs across all repos using this shared config, preventing supply chain attacks.

Fixes https://linear.app/cloudquery/issue/ENG-3118/pin-all-github-actions-to-prevent-supply-chain-attacks