### PR TITLE
chore: Disable Python support in Renovate configuration

### DIFF
--- a/.github/renovate-python-default.json5
+++ b/.github/renovate-python-default.json5
@@ -1,7 +1,7 @@
 {
   extends: ["github>cloudquery/.github//.github/renovate-default.json5"],
   python: {
-    enabled: true,
+    enabled: false,
   },
   packageRules: [
     {


### PR DESCRIPTION
We're getting duplicate recursive Python PRs so disabling updates until I can figure it out 
<img width="1752" height="921" alt="image" src="https://github.com/user-attachments/assets/8585d1e0-8984-4dc3-93fa-6e37ef4ff327" />
