### PR TITLE
chore: Revert "chore: Disable Python support in Renovate configuration"

### DIFF
--- a/.github/renovate-python-default.json5
+++ b/.github/renovate-python-default.json5
@@ -1,7 +1,7 @@
 {
   extends: ["github>cloudquery/.github//.github/renovate-default.json5"],
   python: {
-    enabled: false,
+    enabled: true,
   },
   packageRules: [
     {


### PR DESCRIPTION
Reverts cloudquery/.github#526

Didn't work I disabled the renovate workflow until we can fix the recursive PRs