### PR TITLE
feat(renovate): Add workflow_dispatch input to target specific repos

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,11 @@
 name: Renovate
 on:
   workflow_dispatch:
+    inputs:
+      repositories:
+        description: "Optional repo(s) to target, e.g. cloudquery/helm-charts-private (comma-separated). Blank = full org autodiscovery."
+        required: false
+        default: ""
   schedule:
     - cron: "0 */2 * * *"
 
@@ -36,6 +41,11 @@ jobs:
           permission-vulnerability-alerts: read
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Configure targeted run
+        if: inputs.repositories != ''
+        run: |
+          echo "RENOVATE_AUTODISCOVER=false" >> "$GITHUB_ENV"
+          echo "RENOVATE_REPOSITORIES=${{ inputs.repositories }}" >> "$GITHUB_ENV"
       - name: Renovate cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:


### PR DESCRIPTION
Adds an optional `repositories` input to the Renovate `workflow_dispatch` trigger so the workflow can be run against a specific repo (or comma-separated list) on demand. When the input is provided, a guarded step disables autodiscovery and sets `RENOVATE_REPOSITORIES`, overriding `autodiscover: true` from the JS config; scheduled and blank-input runs keep full org autodiscovery unchanged. This enables fast, isolated test runs — useful for diagnosing the `401 / Bad credentials` errors caused by the 60-minute GitHub App token expiry on long org-wide runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)